### PR TITLE
Alter Join Line to function more like in vi

### DIFF
--- a/MarvinPlugin/Source/MarvinPlugin/MarvinPlugin.m
+++ b/MarvinPlugin/Source/MarvinPlugin/MarvinPlugin.m
@@ -279,8 +279,13 @@
 - (void)joinLineAction
 {
     if ([self validResponder]) {
-        [self.xcodeManager replaceCharactersInRange:self.xcodeManager.joinRange
-                                         withString:@""];
+        if ([self.xcodeManager lineContentsRange].length > 0) {
+            [self.xcodeManager replaceCharactersInRange:self.xcodeManager.joinRange
+                                             withString:@" "];
+        } else {
+            [self.xcodeManager replaceCharactersInRange:self.xcodeManager.joinRange
+                                             withString:@""];
+        }
     }
 }
 


### PR DESCRIPTION
First off, I love the plugin and appreciate the work you put into it.  In using the Join Line function, I constantly found myself going to the end of the line adding a space before I joined the lines.  I found this a bit cumbersome as I was use to the how vi provide the similar function.

If the current line is not an empty line, a space will be added between
the lines being added.  This will make the Join Line function work like it does
in vi.