### PR TITLE
Add Settings to Enable/Disable Removal of Whitespace

### DIFF
--- a/MarvinPlugin.xcodeproj/project.pbxproj
+++ b/MarvinPlugin.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		524A06551B1F839600F0553A /* Settings.xib in Resources */ = {isa = PBXBuildFile; fileRef = 524A06541B1F839600F0553A /* Settings.xib */; };
+		524A06581B1F86B000F0553A /* MarvinSettingsWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 524A06571B1F86B000F0553A /* MarvinSettingsWindowController.m */; };
+		524A065A1B1F8F1500F0553A /* Defaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 524A06591B1F8F1500F0553A /* Defaults.plist */; };
 		6F44E9F617DD324B0064F1B7 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F44E9F517DD324B0064F1B7 /* Cocoa.framework */; };
 		BD5EBC6519C9F93200F2C8CD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = BD5EBC6119C9F93200F2C8CD /* InfoPlist.strings */; };
 		BD5EBC6A19C9F94700F2C8CD /* MarvinPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = BD5EBC6919C9F94700F2C8CD /* MarvinPlugin.m */; };
@@ -15,6 +18,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		524A06541B1F839600F0553A /* Settings.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = Settings.xib; path = MarvinPlugin/Source/MarvinPlugin/Settings.xib; sourceTree = SOURCE_ROOT; };
+		524A06561B1F86B000F0553A /* MarvinSettingsWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MarvinSettingsWindowController.h; path = MarvinPlugin/Source/MarvinPlugin/MarvinSettingsWindowController.h; sourceTree = SOURCE_ROOT; };
+		524A06571B1F86B000F0553A /* MarvinSettingsWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MarvinSettingsWindowController.m; path = MarvinPlugin/Source/MarvinPlugin/MarvinSettingsWindowController.m; sourceTree = SOURCE_ROOT; };
+		524A06591B1F8F1500F0553A /* Defaults.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Defaults.plist; path = MarvinPlugin/Source/MarvinPlugin/Defaults.plist; sourceTree = SOURCE_ROOT; };
 		6F44E9F217DD324B0064F1B7 /* MarvinPlugin.xcplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MarvinPlugin.xcplugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F44E9F517DD324B0064F1B7 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		6F44E9F817DD324B0064F1B7 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -113,6 +120,10 @@
 				BD5EBC6819C9F94700F2C8CD /* MarvinPlugin.h */,
 				BD5EBC6919C9F94700F2C8CD /* MarvinPlugin.m */,
 				BD9A8A2F19CA09AD00321368 /* XcodeManager.h */,
+				524A06541B1F839600F0553A /* Settings.xib */,
+				524A06561B1F86B000F0553A /* MarvinSettingsWindowController.h */,
+				524A06571B1F86B000F0553A /* MarvinSettingsWindowController.m */,
+				524A06591B1F8F1500F0553A /* Defaults.plist */,
 				BD9A8A3019CA09AD00321368 /* XcodeManager.m */,
 				BD5351FA19CA1159006D3B78 /* XcodePrivate.h */,
 				BDB698F41AB819B8001FC372 /* NSDocument+ZENProperSave.h */,
@@ -173,7 +184,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				524A06551B1F839600F0553A /* Settings.xib in Resources */,
 				BD5EBC6519C9F93200F2C8CD /* InfoPlist.strings in Resources */,
+				524A065A1B1F8F1500F0553A /* Defaults.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -186,6 +199,7 @@
 			files = (
 				BDB698F61AB819B8001FC372 /* NSDocument+ZENProperSave.m in Sources */,
 				BD5EBC6A19C9F94700F2C8CD /* MarvinPlugin.m in Sources */,
+				524A06581B1F86B000F0553A /* MarvinSettingsWindowController.m in Sources */,
 				BD9A8A3119CA09AD00321368 /* XcodeManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MarvinPlugin/Source/MarvinPlugin/Defaults.plist
+++ b/MarvinPlugin/Source/MarvinPlugin/Defaults.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MarvinRemoveWhitespace</key>
+	<true/>
+</dict>
+</plist>

--- a/MarvinPlugin/Source/MarvinPlugin/MarvinPlugin.m
+++ b/MarvinPlugin/Source/MarvinPlugin/MarvinPlugin.m
@@ -23,8 +23,7 @@ static MarvinPlugin *marvinPlugin;
 
 @implementation MarvinPlugin
 
-+ (void)pluginDidLoad:(NSBundle *)plugin
-{
++ (void)pluginDidLoad:(NSBundle *)plugin {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         marvinPlugin = [[self alloc] init];
@@ -35,13 +34,11 @@ static MarvinPlugin *marvinPlugin;
     });
 }
 
-- (void)dealloc
-{
+- (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (instancetype)init
-{
+- (instancetype)init {
     self = [super init];
     if (!self) return nil;
 
@@ -58,8 +55,7 @@ static MarvinPlugin *marvinPlugin;
     return self;
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification *)notification
-{
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
     NSMenuItem *editMenuItem = [[NSApp mainMenu] itemWithTitle:@"Edit"];
 
     if (editMenuItem) {
@@ -180,8 +176,7 @@ static MarvinPlugin *marvinPlugin;
 
 #pragma mark - Getters
 
-- (XcodeManager *)xcodeManager
-{
+- (XcodeManager *)xcodeManager {
     if (_xcodeManager) return _xcodeManager;
 
     _xcodeManager = [[XcodeManager alloc] init];
@@ -189,8 +184,7 @@ static MarvinPlugin *marvinPlugin;
     return _xcodeManager;
 }
 
-- (BOOL)validResponder
-{
+- (BOOL)validResponder {
     NSResponder *firstResponder = [[NSApp keyWindow] firstResponder];
     NSString *responderClass = NSStringFromClass(firstResponder.class);
     NSArray *validClasses = @[@"DVTSourceTextView", @"IDEPlaygroundTextView"];
@@ -200,28 +194,24 @@ static MarvinPlugin *marvinPlugin;
 
 #pragma mark - Actions
 
-- (void)settingsMenuItemSelected:(id)sender
-{
+- (void)settingsMenuItemSelected:(id)sender {
     [marvinPlugin.settingsWindowController showWindow:self];
 }
 
-- (void)selectLineContentsAction
-{
+- (void)selectLineContentsAction {
     if ([self validResponder]) {
         self.xcodeManager.selectedRange = self.xcodeManager.lineContentsRange;
     }
 
 }
 
-- (void)selectWordAction
-{
+- (void)selectWordAction {
     if ([self validResponder]) {
         self.xcodeManager.selectedRange = self.xcodeManager.currentWordRange;
     }
 }
 
-- (void)selectWordAboveAction
-{
+- (void)selectWordAboveAction {
     if ([self validResponder]) {
         NSCharacterSet *validSet = [NSCharacterSet characterSetWithCharactersInString:kMarvinValidSetWordString];
         NSRange currentRange = [self.xcodeManager selectedRange];
@@ -254,8 +244,7 @@ static MarvinPlugin *marvinPlugin;
     }
 }
 
-- (void)selectWordBelowAction
-{
+- (void)selectWordBelowAction {
     if ([self validResponder]) {
         [self performKeyboardEvent:125];
 
@@ -265,31 +254,27 @@ static MarvinPlugin *marvinPlugin;
     }
 }
 
-- (void)selectPreviousWordAction
-{
+- (void)selectPreviousWordAction {
     if ([self validResponder]) {
         self.xcodeManager.selectedRange = self.xcodeManager.previousWordRange;
         self.xcodeManager.selectedRange = self.xcodeManager.currentWordRange;
     }
 }
 
-- (void)selectNextWordAction
-{
+- (void)selectNextWordAction {
     if ([self validResponder]) {
         [self selectWordAction];
     }
 }
 
-- (void)deleteLineAction
-{
+- (void)deleteLineAction {
     if ([self validResponder]) {
         [self.xcodeManager replaceCharactersInRange:self.xcodeManager.lineRange
                                          withString:@""];
     }
 }
 
-- (void)duplicateLineAction
-{
+- (void)duplicateLineAction {
     if ([self validResponder]) {
         NSRange range = [self.xcodeManager lineRange];
         NSString *string = [self.xcodeManager contentsOfRange:range];
@@ -301,8 +286,7 @@ static MarvinPlugin *marvinPlugin;
     }
 }
 
-- (void)joinLineAction
-{
+- (void)joinLineAction {
     if ([self validResponder]) {
         if ([self.xcodeManager lineContentsRange].length > 0) {
             [self.xcodeManager replaceCharactersInRange:self.xcodeManager.joinRange
@@ -314,8 +298,7 @@ static MarvinPlugin *marvinPlugin;
     }
 }
 
-- (void)moveToEOLAndInsertLFAction
-{
+- (void)moveToEOLAndInsertLFAction {
     NSRange lineContentsRange = self.xcodeManager.lineContentsRange;
     NSRange lineRange = [self.xcodeManager lineRange];
 
@@ -349,16 +332,14 @@ static MarvinPlugin *marvinPlugin;
     [self.xcodeManager setSelectedRange:NSMakeRange(endOfLine+1+spacing.length+additionalSpacing.length, 0)];
 }
 
-- (void)properSave
-{
+- (void)properSave {
     [self removeTrailingWhitespace:^{
         [self addNewlineAtEOF];
         [self.xcodeManager save];
     }];
 }
 
-- (void)sortLines
-{
+- (void)sortLines {
     NSRange lineRange = [self.xcodeManager lineRange];
     NSString *selectedContent = [self.xcodeManager contentsOfRange:lineRange];
     NSArray *lines = [selectedContent componentsSeparatedByString:@"\n"];
@@ -382,8 +363,7 @@ static MarvinPlugin *marvinPlugin;
 
 #pragma mark - Private methods
 
-- (void)addNewlineAtEOF
-{
+- (void)addNewlineAtEOF {
     if ([self validResponder]) {
 
         NSString *documentText = self.xcodeManager.contents;
@@ -405,8 +385,7 @@ static MarvinPlugin *marvinPlugin;
     }
 }
 
-- (void)removeTrailingWhitespace:(void (^)())block
-{
+- (void)removeTrailingWhitespace:(void (^)())block {
     if (![self validResponder]) {
         block();
         return;
@@ -457,8 +436,7 @@ static MarvinPlugin *marvinPlugin;
     });
 }
 
-- (void)performKeyboardEvent:(CGKeyCode)virtualKey
-{
+- (void)performKeyboardEvent:(CGKeyCode)virtualKey {
     CGEventRef event = CGEventCreateKeyboardEvent(NULL, virtualKey, true);
     CGEventSetFlags(event, 0);
     CGEventPost(kCGHIDEventTap, event);

--- a/MarvinPlugin/Source/MarvinPlugin/MarvinSettingsWindowController.h
+++ b/MarvinPlugin/Source/MarvinPlugin/MarvinSettingsWindowController.h
@@ -1,0 +1,17 @@
+//
+//  MarvinSettingsWindowController.h
+//  MarvinPlugin
+//
+//  Created by David Peak on 6/3/15.
+//  Copyright (c) 2015 Octalord Information Inc. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface MarvinSettingsWindowController : NSWindowController
+
+@property (weak) IBOutlet NSButton *shouldRemoveWhitespace;
+
+- (instancetype)initWithBundle:(NSBundle *)bundle;
+
+@end

--- a/MarvinPlugin/Source/MarvinPlugin/MarvinSettingsWindowController.m
+++ b/MarvinPlugin/Source/MarvinPlugin/MarvinSettingsWindowController.m
@@ -1,0 +1,40 @@
+//
+//  MarvinSettingsWindowController.m
+//  MarvinPlugin
+//
+//  Created by David Peak on 6/3/15.
+//  Copyright (c) 2015 Octalord Information Inc. All rights reserved.
+//
+
+#import "MarvinSettingsWindowController.h"
+
+@interface MarvinSettingsWindowController ()
+{
+    NSDictionary   *_defaults;
+    NSUserDefaults *_userDefaults;
+}
+
+@end
+
+@implementation MarvinSettingsWindowController
+
+- (id)initWithBundle:(NSBundle *)bundle
+{
+    NSString *nibPath = [bundle pathForResource:@"Settings" ofType:@"nib"];
+    self = [super initWithWindowNibPath:nibPath owner:self];
+    if (self)
+    {
+        NSString *defaultsFilePath = [bundle pathForResource:@"Defaults" ofType:@"plist"];
+        _defaults = [NSDictionary dictionaryWithContentsOfFile:defaultsFilePath];
+        _userDefaults = [NSUserDefaults standardUserDefaults];
+    }
+    return self;
+}
+
+- (void)windowDidLoad {
+    [super windowDidLoad];
+
+    // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
+}
+
+@end

--- a/MarvinPlugin/Source/MarvinPlugin/Settings.xib
+++ b/MarvinPlugin/Source/MarvinPlugin/Settings.xib
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7706"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="MarvinSettingsWindowController">
+            <connections>
+                <outlet property="shouldRemoveWhitespace" destination="PCc-Yb-eTt" id="oEw-0M-Pnw"/>
+                <outlet property="window" destination="QvC-M9-y7g" id="3w0-id-Jnq"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Settings - Marvin" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="495" y="479" width="307" height="65"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <view key="contentView" id="EiT-Mj-1SZ">
+                <rect key="frame" x="0.0" y="0.0" width="307" height="65"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PCc-Yb-eTt">
+                        <rect key="frame" x="18" y="29" width="149" height="18"/>
+                        <buttonCell key="cell" type="check" title="Remove Whitespace" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="hM5-HO-WY6">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="7OW-wj-IDa" name="value" keyPath="values.MarvinRemoveWhitespace" id="Tgp-Op-a55">
+                                <dictionary key="options">
+                                    <integer key="NSNullPlaceholder" value="1"/>
+                                </dictionary>
+                            </binding>
+                        </connections>
+                    </button>
+                </subviews>
+            </view>
+            <point key="canvasLocation" x="-337.5" y="212.5"/>
+        </window>
+        <userDefaultsController representsSharedInstance="YES" id="7OW-wj-IDa"/>
+    </objects>
+</document>

--- a/MarvinPlugin/Supporting Files/MarvinPlugIn-Info.plist
+++ b/MarvinPlugin/Supporting Files/MarvinPlugIn-Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.2</string>
+	<string>1.4.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.4.2</string>
+	<string>1.4.3</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>


### PR DESCRIPTION
Add Settings Window to Enable/Disable Removal of Whitespace.  In my
experience, there have been a few times while contributing to public
repos that I don’t want to be too disruptive to the files I modify by
removing the all the whitespace (tabs between statements).  The
addition of the setting option to enable/disable the removal of
whitespace will allow the user to disable the feature as needed.